### PR TITLE
Migration to package mailchimp endpoint

### DIFF
--- a/flowSteps/addCampaignMailchimp/step.js
+++ b/flowSteps/addCampaignMailchimp/step.js
@@ -1,3 +1,9 @@
+/****************************************************
+ Dependencies
+ ****************************************************/
+
+var httpService = dependencies.http;
+
 step.addCampaignMailchimp = function (inputs) {
 
     var inputsLogic = {
@@ -8,10 +14,10 @@ step.addCampaignMailchimp = function (inputs) {
     };
 
     var options = {
-        path: "/campaigns",
+        url: config.get("url") + "/campaigns",
         body: inputsLogic
     }
 
-    return pkg.mailchimp.functions.post(options);
+    return httpService.post(options);
 
 }

--- a/flowSteps/addCampaignMailchimp/step.js
+++ b/flowSteps/addCampaignMailchimp/step.js
@@ -14,7 +14,7 @@ step.addCampaignMailchimp = function (inputs) {
     };
 
     var options = {
-        url: config.get("url") + "/campaigns",
+        url: config.get("mailChimpApiUrl") + "/campaigns",
         body: inputsLogic
     }
 

--- a/flowSteps/addCampaignMailchimp/step.js
+++ b/flowSteps/addCampaignMailchimp/step.js
@@ -15,6 +15,11 @@ step.addCampaignMailchimp = function (inputs) {
 
     var options = {
         url: config.get("mailChimpApiUrl") + "/campaigns",
+        authorization:{
+            type: "basic",
+            username: "anyUser",
+            password: config.get("apiKey")
+        },
         body: inputsLogic
     }
 

--- a/flowSteps/addMemberToListMailchimp/step.js
+++ b/flowSteps/addMemberToListMailchimp/step.js
@@ -1,3 +1,9 @@
+/****************************************************
+ Dependencies
+ ****************************************************/
+
+var httpService = dependencies.http;
+
 step.addMemberToListMailchimp = function (inputs) {
 
     var inputsLogic = {
@@ -12,10 +18,10 @@ step.addMemberToListMailchimp = function (inputs) {
 
 
     var options = {
-        path: "/lists/"+inputsLogic.listId+"/members",
+        url: config.get("url") + "/lists/"+inputsLogic.listId+"/members",
         body: inputsLogic
     }
 
-    return pkg.mailchimp.functions.post(options);
+    return httpService.post(options);
 
 }

--- a/flowSteps/addMemberToListMailchimp/step.js
+++ b/flowSteps/addMemberToListMailchimp/step.js
@@ -18,7 +18,7 @@ step.addMemberToListMailchimp = function (inputs) {
 
 
     var options = {
-        url: config.get("url") + "/lists/"+inputsLogic.listId+"/members",
+        url: config.get("mailChimpApiUrl") + "/lists/"+inputsLogic.listId+"/members",
         body: inputsLogic
     }
 

--- a/flowSteps/addMemberToListMailchimp/step.js
+++ b/flowSteps/addMemberToListMailchimp/step.js
@@ -19,7 +19,12 @@ step.addMemberToListMailchimp = function (inputs) {
 
     var options = {
         url: config.get("mailChimpApiUrl") + "/lists/"+inputsLogic.listId+"/members",
-        body: inputsLogic
+        authorization:{
+            type: "basic",
+            username: "anyUser",
+            password: config.get("apiKey")
+        },
+        body: inputsLogic,
     }
 
     return httpService.post(options);

--- a/flowSteps/apiCallMailchimp/step.js
+++ b/flowSteps/apiCallMailchimp/step.js
@@ -40,7 +40,12 @@ step.apiCallMailchimp = function (inputs) {
 		fileName: inputsLogic.fileName,
 		fullResponse : inputsLogic.fullResponse,
 		connectionTimeout: inputsLogic.connectionTimeout,
-		readTimeout: inputsLogic.readTimeout
+		readTimeout: inputsLogic.readTimeout,
+		authorization:{
+			type: "basic",
+			username: "anyUser",
+			password: config.get("apiKey")
+		}
 	}
 
 	switch (inputsLogic.method.toLowerCase()) {
@@ -49,19 +54,19 @@ step.apiCallMailchimp = function (inputs) {
 		case 'post':
 			return httpService.post(options);
 		case 'delete':
-			return httpService.delete(options);
+			return httpService.delete(setRequestHeaders(options));
 		case 'put':
-			return httpService.put(options);
+			return httpService.put(setRequestHeaders(options));
 		case 'connect':
-			return httpService.connect(options);
+			return httpService.connect(setRequestHeaders(options));
 		case 'head':
-			return httpService.head(options);
+			return httpService.head(setRequestHeaders(options));
 		case 'options':
-			return httpService.options(options);
+			return httpService.options(setRequestHeaders(options));
 		case 'patch':
-			return httpService.patch(options);
+			return httpService.patch(setRequestHeaders(options));
 		case 'trace':
-			return httpService.trace(options);
+			return httpService.trace(setRequestHeaders(options));
 	}
 
 	//REPLACE THIS WITH YOUR OWN CODE

--- a/flowSteps/apiCallMailchimp/step.js
+++ b/flowSteps/apiCallMailchimp/step.js
@@ -1,20 +1,11 @@
-/**
- * This flow step will send generic request.
- *
- * @param {object} inputs
- * {text} method, This is used to config method.
- * {text} url, This is used to config external URL.
- * {Array[string]} pathVariables, This is used to config path variables.
- * {Array[string]} headers, This is used to config headers.
- * {Array[string]} params, This is used to config params.
- * {string} body, This is used to send body request.
- * {boolean} followRedirects, This is used to config follow redirects.
- * {boolean} download, This is used to config download.
- * {boolean} fullResponse, This is used to config full response.
- * {number} connectionTimeout, Read timeout interval, in milliseconds.
- * {number} readTimeout, Connect timeout interval, in milliseconds.
- */
-step.apiCall = function (inputs) {
+/****************************************************
+ Dependencies
+ ****************************************************/
+
+var httpService = dependencies.http;
+
+
+step.apiCallMailchimp = function (inputs) {
 
 	var inputsLogic = {
 		headers: inputs.headers || [],
@@ -39,7 +30,7 @@ step.apiCall = function (inputs) {
 
 
 	var options = {
-		path: parse(inputsLogic.url.urlValue, inputsLogic.url.paramsValue),
+		path: config.get("url") + parse(inputsLogic.url.urlValue, inputsLogic.url.paramsValue),
 		params: inputsLogic.params,
 		headers: inputsLogic.headers,
 		body: inputsLogic.body,
@@ -54,23 +45,23 @@ step.apiCall = function (inputs) {
 
 	switch (inputsLogic.method.toLowerCase()) {
 		case 'get':
-			return pkg.mailchimp.functions.get(options);
+			return httpService.get(options);
 		case 'post':
-			return pkg.mailchimp.functions.post(options);
+			return httpService.post(options);
 		case 'delete':
-			return pkg.mailchimp.functions.delete(options);
+			return httpService.delete(options);
 		case 'put':
-			return pkg.mailchimp.functions.put(options);
+			return httpService.put(options);
 		case 'connect':
-			return pkg.mailchimp.functions.connect(options);
+			return httpService.connect(options);
 		case 'head':
-			return pkg.mailchimp.functions.head(options);
+			return httpService.head(options);
 		case 'options':
-			return pkg.mailchimp.functions.options(options);
+			return httpService.options(options);
 		case 'patch':
-			return pkg.mailchimp.functions.patch(options);
+			return httpService.patch(options);
 		case 'trace':
-			return pkg.mailchimp.functions.trace(options);
+			return httpService.trace(options);
 	}
 
 	//REPLACE THIS WITH YOUR OWN CODE

--- a/flowSteps/apiCallMailchimp/step.js
+++ b/flowSteps/apiCallMailchimp/step.js
@@ -30,7 +30,7 @@ step.apiCallMailchimp = function (inputs) {
 
 
 	var options = {
-		path: config.get("url") + parse(inputsLogic.url.urlValue, inputsLogic.url.paramsValue),
+		path: config.get("mailChimpApiUrl") + parse(inputsLogic.url.urlValue, inputsLogic.url.paramsValue),
 		params: inputsLogic.params,
 		headers: inputsLogic.headers,
 		body: inputsLogic.body,

--- a/flowSteps/campaignInfoMailchimp/step.js
+++ b/flowSteps/campaignInfoMailchimp/step.js
@@ -11,7 +11,12 @@ step.campaignInfoMailchimp = function (inputs) {
 	};
 
 	var options = {
-		url: config.get("mailChimpApiUrl") + "/campaigns/" + inputsLogic.campaignId
+		url: config.get("mailChimpApiUrl") + "/campaigns/" + inputsLogic.campaignId,
+		authorization:{
+			type: "basic",
+			username: "anyUser",
+			password: config.get("apiKey")
+		}
 	}
 
 	return httpService.get(options);

--- a/flowSteps/campaignInfoMailchimp/step.js
+++ b/flowSteps/campaignInfoMailchimp/step.js
@@ -1,3 +1,9 @@
+/****************************************************
+ Dependencies
+ ****************************************************/
+
+var httpService = dependencies.http;
+
 step.campaignInfoMailchimp = function (inputs) {
 
 	var inputsLogic = {
@@ -5,9 +11,9 @@ step.campaignInfoMailchimp = function (inputs) {
 	};
 
 	var options = {
-		path: "/campaigns/" + inputsLogic.campaignId
+		url: config.get("url") + "/campaigns/" + inputsLogic.campaignId
 	}
 
-	return pkg.mailchimp.functions.get(options);
+	return httpService.get(options);
 
 }

--- a/flowSteps/campaignInfoMailchimp/step.js
+++ b/flowSteps/campaignInfoMailchimp/step.js
@@ -11,7 +11,7 @@ step.campaignInfoMailchimp = function (inputs) {
 	};
 
 	var options = {
-		url: config.get("url") + "/campaigns/" + inputsLogic.campaignId
+		url: config.get("mailChimpApiUrl") + "/campaigns/" + inputsLogic.campaignId
 	}
 
 	return httpService.get(options);

--- a/flowSteps/createNewListMailchimp/step.js
+++ b/flowSteps/createNewListMailchimp/step.js
@@ -36,6 +36,11 @@ step.createNewListMailchimp = function (inputs) {
 
     var options = {
         url: config.get("mailChimpApiUrl") + "/lists",
+        authorization:{
+            type: "basic",
+            username: "anyUser",
+            password: config.get("apiKey")
+        },
         body: inputsLogic
     }
 

--- a/flowSteps/createNewListMailchimp/step.js
+++ b/flowSteps/createNewListMailchimp/step.js
@@ -35,7 +35,7 @@ step.createNewListMailchimp = function (inputs) {
     };
 
     var options = {
-        url: config.get("url") + "/lists",
+        url: config.get("mailChimpApiUrl") + "/lists",
         body: inputsLogic
     }
 

--- a/flowSteps/createNewListMailchimp/step.js
+++ b/flowSteps/createNewListMailchimp/step.js
@@ -1,3 +1,9 @@
+/****************************************************
+ Dependencies
+ ****************************************************/
+
+var httpService = dependencies.http;
+
 step.createNewListMailchimp = function (inputs) {
 
     var inputsLogic = {
@@ -29,10 +35,10 @@ step.createNewListMailchimp = function (inputs) {
     };
 
     var options = {
-        path: "/lists",
+        url: config.get("url") + "/lists",
         body: inputsLogic
     }
 
-    return pkg.mailchimp.functions.post(options);
+    return httpService.post(options);
 
 }

--- a/flowSteps/listCampaignsMailchimp/step.js
+++ b/flowSteps/listCampaignsMailchimp/step.js
@@ -7,7 +7,7 @@ var httpService = dependencies.http;
 step.listCampaignsMailchimp = function (inputs) {
 
 	var options = {
-		url: config.get("url") + "/campaigns"
+		url: config.get("mailChimpApiUrl") + "/campaigns"
 	}
 
 	return httpService.get(options);

--- a/flowSteps/listCampaignsMailchimp/step.js
+++ b/flowSteps/listCampaignsMailchimp/step.js
@@ -7,7 +7,12 @@ var httpService = dependencies.http;
 step.listCampaignsMailchimp = function (inputs) {
 
 	var options = {
-		url: config.get("mailChimpApiUrl") + "/campaigns"
+		url: config.get("mailChimpApiUrl") + "/campaigns",
+		authorization:{
+			type: "basic",
+			username: "anyUser",
+			password: config.get("apiKey")
+		}
 	}
 
 	return httpService.get(options);

--- a/flowSteps/listCampaignsMailchimp/step.js
+++ b/flowSteps/listCampaignsMailchimp/step.js
@@ -1,9 +1,15 @@
+/****************************************************
+ Dependencies
+ ****************************************************/
+
+var httpService = dependencies.http;
+
 step.listCampaignsMailchimp = function (inputs) {
 
 	var options = {
-		path: "/campaigns"
+		url: config.get("url") + "/campaigns"
 	}
 
-	return pkg.mailchimp.functions.get(options);
+	return httpService.get(options);
 
 }

--- a/flowSteps/listInfoMailchimp/step.js
+++ b/flowSteps/listInfoMailchimp/step.js
@@ -1,9 +1,15 @@
+/****************************************************
+ Dependencies
+ ****************************************************/
+
+var httpService = dependencies.http;
+
 step.listInfoMailchimp = function (inputs) {
 
 	var options = {
-		path: "/lists"
+		url: config.get("url") + "/lists"
 	}
 
-	return pkg.mailchimp.functions.get(options);
+	return httpService.get(options);
 
 }

--- a/flowSteps/listInfoMailchimp/step.js
+++ b/flowSteps/listInfoMailchimp/step.js
@@ -7,7 +7,7 @@ var httpService = dependencies.http;
 step.listInfoMailchimp = function (inputs) {
 
 	var options = {
-		url: config.get("url") + "/lists"
+		url: config.get("mailChimpApiUrl") + "/lists"
 	}
 
 	return httpService.get(options);

--- a/flowSteps/listInfoMailchimp/step.js
+++ b/flowSteps/listInfoMailchimp/step.js
@@ -6,8 +6,15 @@ var httpService = dependencies.http;
 
 step.listInfoMailchimp = function (inputs) {
 
+	sys.logs.error(JSON.stringify(inputs));
+
 	var options = {
-		url: config.get("mailChimpApiUrl") + "/lists"
+		url: config.get("mailChimpApiUrl") + "/lists",
+		authorization:{
+			type: "basic",
+			username: "anyUser",
+			password: config.get("apiKey")
+		}
 	}
 
 	return httpService.get(options);

--- a/flowSteps/listMembersInfoMailchimp/step.js
+++ b/flowSteps/listMembersInfoMailchimp/step.js
@@ -11,7 +11,12 @@ step.listMembersInfoMailchimp = function (inputs) {
 	};
 
 	var options = {
-		url: config.get("mailChimpApiUrl") + "/lists/" + inputsLogic.listId + "/members"
+		url: config.get("mailChimpApiUrl") + "/lists/" + inputsLogic.listId + "/members",
+		authorization:{
+			type: "basic",
+			username: "anyUser",
+			password: config.get("apiKey")
+		}
 	}
 
 	return httpService.get(options);

--- a/flowSteps/listMembersInfoMailchimp/step.js
+++ b/flowSteps/listMembersInfoMailchimp/step.js
@@ -11,7 +11,7 @@ step.listMembersInfoMailchimp = function (inputs) {
 	};
 
 	var options = {
-		url: config.get("url") + "/lists/" + inputsLogic.listId + "/members"
+		url: config.get("mailChimpApiUrl") + "/lists/" + inputsLogic.listId + "/members"
 	}
 
 	return httpService.get(options);

--- a/flowSteps/listMembersInfoMailchimp/step.js
+++ b/flowSteps/listMembersInfoMailchimp/step.js
@@ -1,3 +1,9 @@
+/****************************************************
+ Dependencies
+ ****************************************************/
+
+var httpService = dependencies.http;
+
 step.listMembersInfoMailchimp = function (inputs) {
 
 	var inputsLogic = {
@@ -5,9 +11,9 @@ step.listMembersInfoMailchimp = function (inputs) {
 	};
 
 	var options = {
-		path: "/lists/" + inputsLogic.listId + "/members"
+		url: config.get("url") + "/lists/" + inputsLogic.listId + "/members"
 	}
 
-	return pkg.mailchimp.functions.get(options);
+	return httpService.get(options);
 
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,13 @@
 			"label": "Configuration",
 			"value": "You will need to configure the Webhook URL in each individual MailChimp list. Please refer to the following web site for information: <a href='http://apidocs.mailchimp.com/webhooks/#configuring-webhooks' target='_blank'>http://apidocs.mailchimp.com/webhooks/#configuring-webhooks</a>",
 			"type": "info"
+		},
+		{
+			"name": "url",
+			"label": "Url",
+			"type": "label",
+			"value": "",
+			"visibility":true
 		}
 	],
 	"events": [

--- a/package.json
+++ b/package.json
@@ -18,6 +18,27 @@
 			"required": true
 		},
 		{
+			"name": "server",
+			"label": "Server",
+			"type": "label",
+			"description": "",
+			"value": "config.apiKey.substring(apiKey.lastIndexOf('-') + 1)"
+		},
+		{
+			"name": "mailChimpServer",
+			"label": "MailChimp Server",
+			"type": "label",
+			"description": "",
+			"value": "config.server == null || server.trim() === '' ? 'us1' : server.trim();"
+		},
+		{
+			"name": "mailChimpApiUrl",
+			"label": "MailChimp Api Url",
+			"type": "label",
+			"description": "",
+			"value": " \"https://\" + config.mailChimpServer + \".api.mailchimp.com/3.0\";"
+		},
+		{
 			"name": "webhook",
 			"label": "Webhook URL",
 			"type": "label",
@@ -28,13 +49,6 @@
 			"label": "Configuration",
 			"value": "You will need to configure the Webhook URL in each individual MailChimp list. Please refer to the following web site for information: <a href='http://apidocs.mailchimp.com/webhooks/#configuring-webhooks' target='_blank'>http://apidocs.mailchimp.com/webhooks/#configuring-webhooks</a>",
 			"type": "info"
-		},
-		{
-			"name": "url",
-			"label": "Url",
-			"type": "label",
-			"value": "",
-			"visibility":true
 		}
 	],
 	"events": [

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -2692,17 +2692,6 @@ var parse = function (str) {
     }
 }
 
-/****************************************************
- Constants
- ****************************************************/
-
-var MANDRILL_API_BASE_URL = config.get("url"); // TODO: Set the base url
-var API_URL = MANDRILL_API_BASE_URL+""; // TODO: Set the base url for the api
-
-var apiKey = config.get("apiKey");
-var server = apiKey.substring(apiKey.lastIndexOf('-') + 1);
-var MAILCHIMP_SERVER = server == null || server.trim() === '' ? 'us1' : server.trim();
-var MAILCHIMP_API_URL = "https://" + MAILCHIMP_SERVER + ".api.mailchimp.com/3.0/";
 
 /****************************************************
  Configurator
@@ -2721,7 +2710,7 @@ var Mailchimp = function (options) {
 
 function setApiUri(options) {
     var url = options.path || "";
-    options.url = MAILCHIMP_API_URL + url;
+    options.url = config.get("mailChimpApiUrl") + url;
     sys.logs.debug('[mailchimp] Set url: ' + options.path + "->" + options.url);
     return options;
 }
@@ -2732,7 +2721,7 @@ function setRequestHeaders(options) {
     authorization = mergeJSON(authorization, {
         type: "basic",
         username: "anyUser",
-        password: apiKey
+        password: config.get("apiKey")
     });
     options.authorization = authorization;
     return options;

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -2,7 +2,7 @@
  Dependencies
  ****************************************************/
 
-var httpReference = svc[config.http];
+var httpReference = dependencies.http;
 
 var httpDependency = {
     get: httpReference.get,
@@ -2696,6 +2696,8 @@ var parse = function (str) {
  Constants
  ****************************************************/
 
+var MANDRILL_API_BASE_URL = config.get("url"); // TODO: Set the base url
+var API_URL = MANDRILL_API_BASE_URL+""; // TODO: Set the base url for the api
 
 var apiKey = config.get("apiKey");
 var server = apiKey.substring(apiKey.lastIndexOf('-') + 1);


### PR DESCRIPTION
Pull-request for issue #14106 created by @agreggio-slingr 

## What it does?

Migrates the MailChimp endpoint to a package

## How to test it?

You can install the following test package using the provided credentials.

API Key: md-2PZnrlxWFPC5FaRExU8BGA

To execute this command in the console, use the following:

pkg.mailchimp.functions.campaigns.get();

Alternatively, you can use the step "List Campaigns Mailchimp" to test the package.

## Implementation notes

N/A